### PR TITLE
Feature: Enforce branch and PR naming conventions (#36)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+Title (required): Type: Short description (#issue-number)
+Example: Feature: Add user authentication (#42)
+
+Summary
+- What does this PR change? Why?
+
+Related Issue
+- Closes #<number>
+
+Type of Change
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Release
+- [ ] Hotfix
+- [ ] Documentation
+
+Checklist
+- [ ] Code compiles and tests pass locally
+- [ ] CI checks pass
+- [ ] Documentation updated (if needed)

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,31 @@
+name: Enforce Branch Naming Convention
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  check-branch-name:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate branch name format
+        shell: bash
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          echo "Branch: $BRANCH"
+          # Allowed: feature/, bugfix/, release/, hotfix/ + kebab/snake/dots
+          regex='^(feature|bugfix|release|hotfix)\/[a-z0-9._-]+$'
+          if [[ ! "$BRANCH" =~ $regex ]]; then
+            echo "::error title=Invalid branch name::'$BRANCH' does not match required pattern: $regex"
+            echo "Allowed prefixes: feature/, bugfix/, release/, hotfix/"
+            echo "Examples:"
+            echo "  feature/login-form"
+            echo "  bugfix/incorrect-total"
+            echo "  release/1.2.0"
+            echo "  hotfix/crash-on-signup"
+            exit 1
+          fi
+          echo "Branch name OK ✅"

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -16,16 +16,18 @@ jobs:
           BRANCH: ${{ github.head_ref }}
         run: |
           echo "Branch: $BRANCH"
-          # Allowed: feature/, bugfix/, release/, hotfix/ + kebab/snake/dots
-          regex='^(feature|bugfix|release|hotfix)\/[a-z0-9._-]+$'
+          # Allowed: feature/, bugfix/, release/, hotfix/ + issue number + hyphen + slug
+          # Example: feature/32-user-authentication
+          regex='^(feature|bugfix|release|hotfix)/[0-9]+-[a-z0-9._-]+$'
           if [[ ! "$BRANCH" =~ $regex ]]; then
             echo "::error title=Invalid branch name::'$BRANCH' does not match required pattern: $regex"
-            echo "Allowed prefixes: feature/, bugfix/, release/, hotfix/"
+            echo "Required format: <type>/<issue-number>-<kebab-or-slug>"
+            echo "Allowed types: feature, bugfix, release, hotfix"
             echo "Examples:"
-            echo "  feature/login-form"
-            echo "  bugfix/incorrect-total"
-            echo "  release/1.2.0"
-            echo "  hotfix/crash-on-signup"
+            echo "  feature/32-user-authentication"
+            echo "  bugfix/145-incorrect-total"
+            echo "  release/210-1.2.0"
+            echo "  hotfix/501-crash-on-signup"
             exit 1
           fi
           echo "Branch name OK ✅"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,31 @@
+name: Enforce PR Title Convention
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  check-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate title format
+        shell: bash
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR Title: $TITLE"
+          # Required format: "Type: Description (#123)"
+          # Types: Feature, Bugfix, Release, Hotfix
+          regex='^(Feature|Bugfix|Release|Hotfix): .+ \(#([0-9]+)\)$'
+          if [[ ! "$TITLE" =~ $regex ]]; then
+            echo "::error title=Invalid PR title::'$TITLE' does not match required format: 'Type: Description (#123)'."
+            echo "Examples:"
+            echo "  Feature: Add user authentication (#42)"
+            echo "  Bugfix: Fix total calculation on invoice (#56)"
+            echo "  Release: Prepare for v1.2.0 (#78)"
+            echo "  Hotfix: Resolve crash on signup (#91)"
+            exit 1
+          fi
+          echo "PR title OK ✅"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Run services locally without Docker (optional):
 - Frontend (Vite/Ionic) dev:
   pnpm -C app dev -- --host 0.0.0.0 --port 5173
 
+## naming conventions
+### Branch naming rules
+a branch should always start with the type, then the issue number and then the description
+for example:
+
+feature/12-user-authentication
+bugfix/login-redirect-error
+
+### PR naming rules
+a PR should always begin with the type, then the description and then the issue number
+for example:
+
+Feature: Add OAuth2 authentication (#145)
+Bugfix: Fix mobile responsive layout (#298)
+Release: Prepare version 2.1.0 (#312)
+Hotfix: Resolve SQL injection vulnerability (#456)
+
 ## Frontend
 
 Voor de frontend van **Bobber** verkennen we twee krachtige frameworks die beide mobiele én webapplicaties ondersteunen vanuit één codebase: **Quasar** en **Ionic**. Beide zijn geschikt voor PWA's, native apps (via Capacitor), en snelle ontwikkeling met moderne frontend stacks.


### PR DESCRIPTION
# naming conventions
## Branch naming rules
a branch should always start with the type, then the issue number and then the description
for example:

feature/12-user-authentication
bugfix/login-redirect-error

## PR naming rules
a PR should always begin with the type, then the description and then the issue number
for example:

Feature: Add OAuth2 authentication (#145)
Bugfix: Fix mobile responsive layout (#298)
Release: Prepare version 2.1.0 (#312)
Hotfix: Resolve SQL injection vulnerability (#456)